### PR TITLE
removed reference to GM_log as it is deprecated

### DIFF
--- a/gm_config.js
+++ b/gm_config.js
@@ -479,7 +479,7 @@ GM_configStruct.prototype = {
   GM_configStruct.prototype.stringify = stringify;
   GM_configStruct.prototype.parser = parser;
   GM_configStruct.prototype.log = window.console ? console.log :
-                                    ( typeof GM_log !== 'undefined' ? GM_log :
+                                    ( isGM ? GM_log :
                                         (window.opera ? opera.postError : function(){})
                                     );
 })();


### PR DESCRIPTION
GM_log is deprecated. The usage of it causes errors in Tampermonkey on Chrome.
