### PR TITLE
Fix Firefox log error

### DIFF
--- a/gm_config.js
+++ b/gm_config.js
@@ -478,9 +478,9 @@ GM_configStruct.prototype = {
   GM_configStruct.prototype.stringify = stringify;
   GM_configStruct.prototype.parser = parser;
   GM_configStruct.prototype.log =  window.console ?
-    console.log : (isGM && typeof GM_log != 'undefined' ?
+    console.log.bind(console) : (isGM && typeof GM_log != 'undefined' ?
       GM_log : (window.opera ?
-        opera.postError : function(){ /* no logging */ }
+        opera.postError.bind(opera) : function(){ /* no logging */ }
   ));
 })();
 


### PR DESCRIPTION
> "'log' called on an object that does not implement interface Console."

https://bugzilla.mozilla.org/show_bug.cgi?id=989619

To reproduce the error, disable cookies (and don't enable `GM_getValue`/`GM_setValue`) so that GM_config can't save or read settings.
