### PR TITLE
fix hg-pages script src

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
-<script src="https://github.com/sizzlemctwizzle/GM_config/raw/master/gm_config.js" type="text/javascript"></script>
+<script src="https://rawgit.com/sizzlemctwizzle/GM_config/master/gm_config.js" type="text/javascript"></script>
 </head>
 <body>
-<script src="https://github.com/sizzlemctwizzle/UserScripts/raw/master/gm_config_unit_test.user.js" type="text/javascript"></script>
+<script src="https://rawgit.com/sizzlemctwizzle/UserScripts/master/gm_config_unit_test.user.js" type="text/javascript"></script>
 </body>
 </html>


### PR DESCRIPTION
hg-pages can't work. Error with

>Refused to execute script from 'https://github.com/sizzlemctwizzle/GM_config/raw/master/gm_config.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
>
>Refused to execute script from 'https://github.com/sizzlemctwizzle/UserScripts/raw/master/gm_config_unit_test.user.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled