### PR TITLE
Fix newer agents

### DIFF
--- a/gm_config.js
+++ b/gm_config.js
@@ -322,8 +322,15 @@ GM_configStruct.prototype = {
       // In WebKit src can't be set until it is added to the page
       this.frame.src = 'about:blank';
       // we wait for the iframe to load before we can modify it
+      var that = this;
       this.frame.addEventListener('load', function(e) {
           var frame = config.frame;
+          if (frame.src && !frame.contentDocument) {
+            // Some agents need this as an empty string for newer context implementations
+            frame.src = "";
+          } else if (!frame.contentDocument) {
+            that.log("GM_config failed to initialize default settings dialog node!");
+          }
           var body = frame.contentDocument.getElementsByTagName('body')[0];
           body.id = config.id; // Allows for prefixing styles with the config id
           buildConfigWin(body, frame.contentDocument.getElementsByTagName('head')[0]);


### PR DESCRIPTION
* For at maximum of ~three years GM4 hasn't worked with GM_config but did for ~eight of GM's total life span... apply a patch. Thanks to @arantius for an idea I never would have thought of trying.
* Also fixes newest Edge compatibility
* Should be backward compatible with WebKit.
* Known issue of GMC not working at all in Falkon... outdated atm and I'll look into that when I have more time.
* Added a log message if the browser allows it. SM does. No cleanup of object yet on complete failure as this is something we want to know to fix if it changes in the future... keeping things small for the moment.

Applies to #97

Note(s):
* Setting `src` to null was interesting... loading a 404 from OUJS so went with empty string and seems to work well.