### PR TITLE
Make field reload() work more than once

### DIFF
--- a/gm_config.js
+++ b/gm_config.js
@@ -839,7 +839,7 @@ GM_configField.prototype = {
   },
 
   remove: function(el) {
-    GM_configStruct.remove(el || this.wrapper);
+    GM_config.remove(el || this.wrapper);
     this.wrapper = null;
     this.node = null;
   },
@@ -848,8 +848,10 @@ GM_configField.prototype = {
     var wrapper = this.wrapper;
     if (wrapper) {
       var fieldParent = wrapper.parentNode;
-      fieldParent.insertBefore((this.wrapper = this.toNode()), wrapper);
-      this.remove(wrapper);
+      var newWrapper = this.toNode();
+      fieldParent.insertBefore(newWrapper, wrapper);
+      this.remove();
+      this.wrapper = newWrapper;
     }
   },
 


### PR DESCRIPTION
This change fixes #62, which was incorrectly closed and has been a bug ever since the `reload` feature was added. This changed is based on #111 instead of master, since the change is highly localized. Will merge this into `new-constructor` before merging that branch into master.