### PR TITLE
Fix: Minor spelling mistake

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,7 +36,7 @@ type FieldTypes =
     | 'select'
     | 'checkbox'
     | 'unsigned int'
-    | 'unsinged integer'
+    | 'unsigned integer'
     | 'int'
     | 'integer'
     | 'float'


### PR DESCRIPTION
The field type `unsigned float` was accidentally spelled as `unsinged float`.